### PR TITLE
Add info message for user

### DIFF
--- a/distlock.go
+++ b/distlock.go
@@ -88,7 +88,8 @@ func AquireLock(bucketName string, prefix string, region string) string {
 	rPrefix := fmt.Sprintf("%v/locks/%v.lock", prefix, u1.String())
 
 	uploadedVersion := PutLockS3(bucketName, rPrefix, region)
-
+	
+	fmt.Printf("Waiting for lock %v\n", rPrefix)
 	for true {
 		versionPrefix := fmt.Sprintf("%v/locks", prefix)
 		version := GetOldestVersion(bucketName, versionPrefix, region)


### PR DESCRIPTION
Add an extra println, so that the user is aware there is a lock problem, in the event there is.
A huge amount of time, might be spent waiting on a lock we will never receive. This will alert us.